### PR TITLE
chore(ci): verify commit in live readiness smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           IMAGE=${{ steps.prep.outputs.image }}
           SHA=${{ steps.prep.outputs.sha }}
-          docker build -t "$IMAGE:$SHA" -f Dockerfile .
+          docker build --build-arg SOURCE_COMMIT="${GITHUB_SHA}" -t "$IMAGE:$SHA" -f Dockerfile .
           docker tag "$IMAGE:$SHA" "$IMAGE:main"
           if [ -n "${{ github.event.inputs.tag }}" ]; then docker tag "$IMAGE:$SHA" "$IMAGE:${{ github.event.inputs.tag }}"; fi
           docker push "$IMAGE:$SHA"
@@ -80,11 +80,21 @@ jobs:
       - name: Readiness smoke (public)
         run: |
           URL="https://movie-mate.de/api/v1/health/ready"
+          EXPECT="${GITHUB_SHA::7}"
+          echo "Expecting commit: $EXPECT"
           for i in {1..12}; do
-            code=$(curl -fsS -o /dev/null -w "%{http_code}" "$URL" || true)
+            # Get JSON and status code
+            body=$(curl -fsS "$URL" -w "\n%{http_code}" || true)
+            code=$(echo "$body" | tail -n1)
+            json=$(echo "$body" | sed '$d')
             if [ "$code" = "200" ]; then
-              echo "Ready: $URL (200)"; exit 0
+              commit=$(echo "$json" | jq -r '.commit // empty' 2>/dev/null || true)
+              if [ -n "$commit" ] && [ "$commit" = "$EXPECT" ]; then
+                echo "Ready: $URL (200, commit $commit)"; exit 0
+              fi
+              echo "Attempt $i/12 -> 200 but commit='$commit' != '$EXPECT'; retrying in 10s…"; sleep 10
+              continue
             fi
             echo "Attempt $i/12 -> $code; retrying in 10s…"; sleep 10
           done
-          echo "Live readiness failed for $URL"; exit 1
+          echo "Live readiness failed for $URL (commit did not match $EXPECT)"; exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ COPY apps ./apps
 COPY packages ./packages
 COPY scripts ./scripts
 
+# Inject source commit into the image for health reporting
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 # Install and build
 RUN pnpm install --frozen-lockfile=false \
  && pnpm -C apps/api build \

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -61,7 +61,7 @@ curl -i -X POST \
 - `.github/workflows/deploy.yml`
   - `build-push`: build + push image to GHCR (läuft automatisch nur, wenn CI grün ist; sonst nur manuell).
   - `coolify-deploy`: POST to `COOLIFY_WEBHOOK_URL` (adds `Authorization: Bearer` if token provided).
-  - `live-smoke`: prüft nach dem Deploy bis zu 12× (10s Backoff) die öffentliche Readiness unter `/api/v1/health/ready` und schlägt bei Nicht‑200 fehl.
+  - `live-smoke`: prüft nach dem Deploy bis zu 12× (10s Backoff) die öffentliche Readiness unter `/api/v1/health/ready` und verifiziert zusätzlich, dass das Feld `commit` dem aktuell gebauten Commit (`${GITHUB_SHA::7}`) entspricht. Nur dann gilt der Smoke-Test als bestanden.
   - Hinweis: DB‑Migrationen laufen im Container‑Entrypoint (siehe Dockerfile `ENTRYPOINT scripts/docker-entry.sh`), daher ist kein DB‑Zugriff vom GitHub Runner nötig.
 
 - `.github/workflows/backup-db.yml` (optional)


### PR DESCRIPTION
Verbessert Live-Readiness-Signal nach Coolify-Deploy:

- Docker: Commit-SHA als SOURCE_COMMIT ins Image gebacken
- Deploy-Workflow: übergibt GITHUB_SHA als Build-Arg
- Live-Smoke: prüft /api/v1/health/ready (12×/10s) und verifiziert, dass .commit == ${GITHUB_SHA::7}
- Docs: Hinweis auf Commit-Verifikation ergänzt

Risiken/Trade-offs: Mit Commit-Prüfung schlagen alte Container sofort fehl → frühzeitiges Feedback bei Rollback/Propagation-Delays.
ENV/Docker/Docs: keine neuen Secrets; nur Build-Arg und Doku.