### PR TITLE
feat(security): prod guard against dev JWT defaults + rotation runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Warn on dev default secrets (non-blocking)
+        run: rg -n "dev-(refresh-)?secret-change-me" -g '!**/.env.example' -g '!docs/**' || true
+
       - name: Test with coverage
         run: pnpm exec jest --coverage --passWithNoTests --coverageReporters=text --coverageReporters=lcov --coverageReporters=json-summary --coverageReporters=html --runInBand
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,10 @@ jobs:
 
       - name: Run container and liveness smoke test
         run: |
-          docker run -d --rm -p 3000:3000 --name mm-test movie-mate:test
+          docker run -d --rm -p 3000:3000 --name mm-test \
+            -e JWT_SECRET=test-secret-ci-access-1234567890 \
+            -e JWT_REFRESH_SECRET=test-secret-ci-refresh-1234567890 \
+            movie-mate:test
           for i in {1..30}; do \
             curl -fsS http://127.0.0.1:3000/api/v1/health && exit 0 || sleep 1; \
           done; \
@@ -180,6 +183,8 @@ jobs:
           # Start API with DATABASE_URL pointing to mm-db
           docker run -d --rm --network mm-net -p 3000:3000 --name mm-test \
             -e DATABASE_URL=postgresql://postgres:postgres@mm-db:5432/app \
+            -e JWT_SECRET=test-secret-ci-access-1234567890 \
+            -e JWT_REFRESH_SECRET=test-secret-ci-refresh-1234567890 \
             movie-mate:test
           # Wait for readiness
           for i in {1..60}; do \

--- a/apps/api/__tests__/config.schema.test.ts
+++ b/apps/api/__tests__/config.schema.test.ts
@@ -10,4 +10,34 @@ describe('Config schema', () => {
   it('rejects invalid port', () => {
     expect(() => validateEnv({ PORT: 'not-a-number' } as any)).toThrow()
   })
+
+  it('throws in production when using dev default JWT secrets', () => {
+    expect(() => validateEnv({ NODE_ENV: 'production' } as any)).toThrow(
+      /Unsafe JWT secret configuration/,
+    )
+  })
+
+  it('throws in production when one of the JWT secrets is dev default', () => {
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'production',
+        JWT_SECRET: 'strong-strong-secret-123',
+      } as any),
+    ).toThrow(/Unsafe JWT secret configuration/)
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'production',
+        JWT_REFRESH_SECRET: 'strong-strong-refresh-456',
+      } as any),
+    ).toThrow(/Unsafe JWT secret configuration/)
+  })
+
+  it('accepts production when both JWT secrets are strong and non-default', () => {
+    const out = validateEnv({
+      NODE_ENV: 'production',
+      JWT_SECRET: 'strong-strong-secret-123',
+      JWT_REFRESH_SECRET: 'strong-strong-refresh-456',
+    } as any)
+    expect(out.NODE_ENV).toBe('production')
+  })
 })

--- a/apps/api/src/config/config.schema.ts
+++ b/apps/api/src/config/config.schema.ts
@@ -30,6 +30,17 @@ export function validateEnv(raw: Record<string, unknown>) {
     const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')
     throw new Error(`Invalid environment configuration: ${issues}`)
   }
+  // Production guard against dev default JWT secrets
+  if (parsed.data.NODE_ENV === 'production') {
+    if (
+      parsed.data.JWT_SECRET === 'dev-secret-change-me' ||
+      parsed.data.JWT_REFRESH_SECRET === 'dev-refresh-secret-change-me'
+    ) {
+      throw new Error(
+        'Unsafe JWT secret configuration in production. Please set strong JWT secrets. See docs/ops-secrets.md.',
+      )
+    }
+  }
   const cors = (parsed.data.CORS_ALLOWLIST || '')
     .split(',')
     .map((s) => s.trim())

--- a/docs/ops-secrets.md
+++ b/docs/ops-secrets.md
@@ -1,0 +1,79 @@
+# Secrets-Runbook und Produktions-Guards
+
+Dieses Runbook beschreibt die Verwaltung und Rotation von Secrets (insb. JWT-Secrets) und dokumentiert produktionsseitige Guards gegen die Nutzung von Dev-Defaults.
+
+## Secret-Typen
+
+- JWT Access Secret: Signiert Access Tokens. Kurzlebig (z. B. 15 Minuten).
+- JWT Refresh Secret: Signiert Refresh Tokens. Längerlebig (z. B. 30 Tage).
+
+Hinweise:
+
+- Keine Secrets im Repository speichern. Niemals in Git committen.
+- Secrets werden in Produktion ausschließlich über Coolify/Env-Variablen gesetzt.
+- Für lokale Entwicklung stehen Dev-Defaults in `.env.example` zur Verfügung.
+
+## Erzeugung (256-bit random, base64url)
+
+Empfehlung: 32 Bytes kryptographisch sichere Zufallsdaten, base64url-kodiert.
+
+Beispiele:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+```
+
+Optionales Script (komfortabel, erzeugt Access/Refresh):
+
+```bash
+pnpm -s tsx scripts/generate-secrets.ts
+```
+
+## Setzen der Secrets (Produktion)
+
+- In Coolify für den API-Container die Env-Variablen setzen/ändern:
+  - `JWT_SECRET`
+  - `JWT_REFRESH_SECRET`
+- Änderungen werden beim nächsten Deploy/Restart wirksam.
+
+## Rotation
+
+Ziel: Zero-Downtime-Rotation ist ideal, ansonsten kurzes Zeitfenster einplanen.
+
+Schritte (empfohlen):
+
+1. Vorbereitung: Neue Secrets generieren (Access/Refresh separat!) und sicher ablegen.
+2. Rollout planen: Kurzfristiges Wartungsfenster ankündigen (falls nötig).
+3. Deploy: In Coolify die neuen Secrets setzen und den Dienst neu starten.
+4. Verifikation (siehe unten) durchführen.
+
+Auswirkungen:
+
+- Access Tokens, die mit dem alten Secret signiert wurden, sind nach Rotation ungültig.
+- Refresh Tokens sind ebenfalls ungültig; Benutzer müssen sich ggf. erneut anmelden.
+- In der Regel genügt ein erneutes Login. Planen Sie Support/Monitoring ein.
+
+Rollback:
+
+- Alte Secrets sicher bereithalten. Bei Problemen Wechsel zurück, dann Ursache analysieren.
+
+## Produktions-Guards (Fail-Fast)
+
+In `apps/api/src/config/config.schema.ts` wird in `NODE_ENV=production` ein Start abgebrochen, wenn Dev-Defaults verwendet werden:
+
+- `JWT_SECRET === 'dev-secret-change-me'` oder
+- `JWT_REFRESH_SECRET === 'dev-refresh-secret-change-me'`
+
+Fehlerhinweis verweist auf dieses Dokument.
+
+## Verifikation nach Rotation
+
+- Health: `GET /api/v1/health` und `GET /api/v1/health/ready` prüfen.
+- Auth-Flows: Login durchführen, Access/Refresh Token ausstellen/prüfen.
+- Fehler-Monitoring: 4xx/5xx-Rate, Auth-spezifische Fehler, Logs prüfen.
+
+## Sicherheitshinweise
+
+- Secrets regelmäßig rotieren und mindestens wie Passwörter behandeln.
+- Zugriff nur für berechtigte Personen; Audit/Versionierung in Coolify/Secret-Store nutzen.
+- Keine Secrets in Logs, Commits, PRs oder Issue-Texten.

--- a/scripts/generate-secrets.ts
+++ b/scripts/generate-secrets.ts
@@ -1,0 +1,13 @@
+import { randomBytes } from 'crypto'
+
+function gen(size = 32) {
+  return randomBytes(size).toString('base64url')
+}
+
+const access = gen(32)
+const refresh = gen(32)
+
+// Output with labels
+console.log('Generated JWT secrets:')
+console.log(`- ACCESS (JWT_SECRET):        ${access}`)
+console.log(`- REFRESH (JWT_REFRESH_SECRET): ${refresh}`)

--- a/tasks.md
+++ b/tasks.md
@@ -70,7 +70,7 @@ Milestones
 
 - [x] Add Helmet (secure HTTP headers) (2025-08-29)
 - [x] Finalize CORS allowlist (`FRONTEND_URL`, staging) (2025-08-30)
-- [ ] Ensure strong JWT secrets + rotation plan documented
+- [x] Ensure strong JWT secrets + rotation plan documented (2025-08-30)
 - [x] Add Docker HEALTHCHECK (2025-08-29)
 - [x] Non-root container user (optional hardening) (2025-08-30)
 - [x] Housekeeping: purge expired `refresh_tokens` (2025-08-29)


### PR DESCRIPTION
- Fügt Produktions‑Guards gegen Dev‑JWT‑Defaults hinzu; ergänzt docs/ops-secrets.md
- Betroffene Dateien: apps/api/src/config/config.schema.ts, docs/ops-secrets.md, scripts/generate-secrets.ts, .github/workflows/ci.yml (Warnstep)
- Tests: keine Laufzeit‑Tests erforderlich; Verhalten ändert sich nur in NODE_ENV=production
- Risiken/Trade-offs: Strikteres Fail‑Fast in Prod; Deployment scheitert bei fehlender Secret‑Konfiguration → erwünscht
- ENV/Docker/Docs: Doku vorhanden; .env.example bleibt unverändert