### PR TITLE
chore(ci): enforce format check and stabilize CI check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,6 +44,9 @@ jobs:
       # Install / Lint / Typecheck / Test
       - name: Install
         run: pnpm install --frozen-lockfile=false
+
+      - name: Format check
+        run: pnpm format:check
 
       - name: Lint
         run: pnpm lint

--- a/docs/ci-guidelines.md
+++ b/docs/ci-guidelines.md
@@ -7,9 +7,10 @@ This doc summarizes the practical setup we use and how to enforce quality on Pul
 Recommended to enable on `main`:
 
 - CI (ci.yml)
-  - build-test
-  - E2E (DB, Testcontainers)
-  - Release Check (Docker build + liveness/readiness smoke)
+  - CI / Build & Test
+  - CI / E2E (DB, Testcontainers)
+  - CI / Release Check (Docker build + smoke)
+  - CI / Prisma Migrate Dry Run
 - Lint/Typecheck are inside CI build-test; making the entire job required is sufficient.
 
 Optional (keep non-blocking):
@@ -34,8 +35,8 @@ How to configure:
 
 ## What Each Job Covers
 
-- build-test
-  - pnpm install, lint, typecheck
+- Build & Test
+  - pnpm install, format check (`pnpm format:check` fail-fast), lint, typecheck
   - jest with coverage (uploads lcov + summary + HTML)
 - E2E (DB)
   - Runs e2e tests that need a database (Testcontainers)
@@ -44,7 +45,7 @@ How to configure:
   - Trivy image scan (non-blocking)
   - Liveness smoke: `GET /health`
   - Readiness smoke with Postgres container: `GET /health/ready`
-- migrate-dry-run
+- Prisma Migrate Dry Run
   - führt `prisma migrate deploy` gegen eine ephemere Postgres-Instanz aus; fängt Migrationsfehler früh ab; nutzt keine Secrets.
 - Quality (optional)
   - Coverage gate ≥ 70% (non-blocking)


### PR DESCRIPTION
Was und warum:
- Fügt `pnpm format:check` als fail‑fast in „Build & Test“ hinzu.
- Setzt/vereinheitlicht Job‑Namen für stabile Branch‑Protection‑Checks.

Betroffene Dateien:
- `.github/workflows/ci.yml`, `docs/ci-guidelines.md`

Tests:
- Keine App‑Tests; CI verifiziert die Änderungen.

Risiken/Trade-offs:
- PRs mit Format‑Drift scheitern früher (gewollt).

ENV/Docker/Docs:
- Keine neuen Secrets; Guidelines aktualisiert.

Checkliste:
- [x] `build-test` Job benannt („Build & Test“) und `pnpm format:check` hinzugefügt
- [x] `docs/ci-guidelines.md` aktualisiert (Check‑Namen + Format‑Check)
- [x] `pnpm test` lokal grün
- [x] `pnpm typecheck` grün, `pnpm lint` grün
- [x] `pnpm format` ausgeführt
- [x] Keine Änderungen an `.env.example`
