### PR TITLE
feat(security): enforce secure cookies in production when cookie mode is enabled

### DIFF
--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -24,6 +24,7 @@
 - `REFRESH_TOKEN_COOKIE=true` enables httpOnly refresh cookie + CSRF cookie
 - CSRF header: `x-csrf-token` must match `csrfToken` cookie
 - `COOKIE_SECURE`, `COOKIE_DOMAIN`, `REFRESH_COOKIE_NAME`, `CSRF_COOKIE_NAME`, `CSRF_HEADER_NAME`
+  - Security: In production, when `REFRESH_TOKEN_COOKIE=true`, you must set `COOKIE_SECURE=true` (fail-fast guard). Optionally set `COOKIE_DOMAIN` to your app domain for cross-subdomain cookies.
 
 ## Error Codes Alignment
 


### PR DESCRIPTION
Prod‑Guard für Cookie‑Modus (REFRESH_TOKEN_COOKIE) ergänzt.\n\nÄnderungen:\n- Enforce: In Production, wenn REFRESH_TOKEN_COOKIE==='true' dann COOKIE_SECURE==='true' (Fail‑Fast) in apps/api/src/config/config.schema.ts.\n- Tests in apps/api/__tests__/config.schema.test.ts ergänzt.\n- Doku-Hinweis in docs/backend-overview.md (Security/Cookie Mode).\n\nCheckliste:\n- [x] Branch/PR erstellt\n- [x] Guard implementiert\n- [x] Tests ergänzt\n- [x] Docs aktualisiert\n- [x] pnpm test/typecheck/lint grün\n- [x] pnpm format ausgeführt